### PR TITLE
Enhanced the content generater page

### DIFF
--- a/client/src/components/Markdown.tsx
+++ b/client/src/components/Markdown.tsx
@@ -122,7 +122,16 @@ function MarkdownComponent({ source }: MarkdownProps) {
       className="markdown-body"
       dangerouslySetInnerHTML={{ __html: html }}
       sx={{
-        '& h1, & h2, & h3, & h4, & h5, & h6': { color: 'gray.800', marginBottom: 3, marginTop: 5 },
+        '& h1, & h2, & h3, & h4, & h5, & h6': {
+          color: 'gray.800',
+          marginBottom: 3,
+          marginTop: 6,
+          fontWeight: 700,
+          letterSpacing: '-0.02em'
+        },
+        '& h1': { fontSize: { base: '2xl', md: '3xl' }, borderBottom: '1px solid', borderColor: 'gray.200', paddingBottom: 2 },
+        '& h2': { fontSize: { base: 'xl', md: '2xl' }, marginTop: 6 },
+        '& h3': { fontSize: { base: 'lg', md: 'xl' }, marginTop: 5 },
         '& h1[id]::before, & h2[id]::before, & h3[id]::before, & h4[id]::before, & h5[id]::before, & h6[id]::before': {
           content: '""',
           display: 'block',
@@ -130,12 +139,22 @@ function MarkdownComponent({ source }: MarkdownProps) {
           marginTop: '-80px',
           visibility: 'hidden'
         },
-        '& p': { color: 'gray.700', lineHeight: '1.8', marginBottom: 3 },
-        '& ul, & ol': { color: 'gray.700', paddingLeft: 6, marginBottom: 3 },
+        '& p': { color: 'gray.700', lineHeight: '1.9', marginBottom: 4, fontSize: { base: 'md', md: 'lg' } },
+        '& ul, & ol': { color: 'gray.800', paddingLeft: 6, marginBottom: 4 },
         '& li': { marginBottom: 1.5 },
-        '& pre': { background: 'gray.900', color: 'gray.100', padding: 3, borderRadius: '8px', overflowX: 'auto', marginY: 3 },
-        '& code': { background: 'gray.100', borderRadius: '4px', paddingX: 1 },
-        '& a': { color: 'blue.500', textDecoration: 'underline' }
+        '& pre': { background: 'gray.900', color: 'gray.100', padding: 4, borderRadius: '10px', overflowX: 'auto', marginY: 4, fontSize: 'sm' },
+        '& code': { background: 'gray.100', borderRadius: '6px', paddingX: 2, paddingY: 0.5, fontSize: '0.95em' },
+        '& a': { color: 'purple.600', textDecoration: 'underline', fontWeight: 500 },
+        '& blockquote': {
+          borderLeft: '4px solid',
+          borderColor: 'purple.200',
+          background: 'purple.50',
+          color: 'gray.700',
+          padding: '12px 16px',
+          borderRadius: '8px',
+          marginY: 4
+        },
+        '& hr': { borderColor: 'gray.200', marginY: 6 }
       }}
     />
   )

--- a/client/src/pages/Content.tsx
+++ b/client/src/pages/Content.tsx
@@ -1,9 +1,9 @@
-import { useState, type ChangeEvent } from 'react'
-import { Box, Button, FormControl, FormLabel, Heading, Input, Select, Stack, Textarea, useToast, SimpleGrid, Text, Icon, HStack, Divider } from '@chakra-ui/react'
+import { useMemo, useRef, useState, type ChangeEvent } from 'react'
+import { Box, Button, FormControl, FormLabel, Heading, Input, Select, Stack, Textarea, useToast, SimpleGrid, Text, Icon, HStack, Divider, Tooltip, Flex, VStack } from '@chakra-ui/react'
 import PrivateLayout from '../components/PrivateLayout'
 import { generateContent, getErrorMessage } from '../api/client'
 import { useNavigate } from 'react-router-dom'
-import { MdAutoAwesome, MdArrowForward } from 'react-icons/md'
+import { MdAutoAwesome, MdArrowForward, MdDownload } from 'react-icons/md'
 import Markdown from '../components/Markdown'
 
 export default function ContentPage() {
@@ -17,6 +17,44 @@ export default function ContentPage() {
   const [contentId, setContentId] = useState<string>('')
   const toast = useToast()
   const navigate = useNavigate()
+  const contentRef = useRef<HTMLDivElement | null>(null)
+
+  const headings = useMemo(() => {
+    if (!content) return [] as Array<{ id: string; text: string; level: number }>
+    const lines = content.split(/\r?\n/)
+    const hs: Array<{ id: string; text: string; level: number }> = []
+    for (const line of lines) {
+      const m = /^(#{1,6})\s+(.*)$/.exec(line)
+      if (m) {
+        const level = m[1].length
+        const text = m[2].trim()
+        const id = text.toLowerCase().replace(/[^a-z0-9\s-]/g, '').trim().replace(/\s+/g, '-')
+        hs.push({ id, text, level })
+      }
+    }
+    return hs
+  }, [content])
+
+  const onDownloadPdf = () => {
+    if (!contentRef.current) return
+    try {
+      const printContents = contentRef.current.innerHTML
+      const win = window.open('', '_blank', 'width=1000,height=800')
+      if (!win) return
+      win.document.write(`<!doctype html><html><head><title>${topic || 'Content'}</title>`)
+      win.document.write('<style>body{font-family:Inter,Segoe UI,Roboto,sans-serif;padding:32px;line-height:1.8;color:#1f2937} h1,h2,h3{color:#111827} .markdown-body pre{background:#111827;color:#f3f4f6;padding:12px;border-radius:8px} .markdown-body code{background:#f3f4f6;padding:2px 6px;border-radius:4px}</style>')
+      win.document.write('</head><body>')
+      win.document.write(`<h1 style="margin-top:0">${topic || 'Study Content'}</h1>`)
+      win.document.write(`<div class="markdown-body">${printContents}</div>`)
+      win.document.write('</body></html>')
+      win.document.close()
+      win.focus()
+      win.print()
+      win.close()
+    } catch (e) {
+      toast({ title: 'Download failed', status: 'error' })
+    }
+  }
 
   const onGenerate = async () => {
     if (!topic.trim()) {
@@ -195,55 +233,94 @@ export default function ContentPage() {
         </Box>
 
         {content && (
-          <Box
-            bg="white"
-            borderRadius="16px"
-            borderWidth="1px"
-            borderColor="gray.200"
-            boxShadow="0 2px 8px rgba(0, 0, 0, 0.06)"
-            overflow="hidden"
-          >
-            <Box bg="purple.50" px={8} py={4}>
-              <Heading size="lg" color="purple.700">Generated Study Material</Heading>
-              <Text color="purple.600">Ready for your review</Text>
-            </Box>
-            
-            <Box p={8} maxW="3xl" mx="auto" lineHeight="tall">
-              <Markdown source={content} />
-            </Box>
+          <Flex gap={8} align="flex-start">
+            <Box flex="1 1 0%"
+              bg="white"
+              borderRadius="16px"
+              borderWidth="1px"
+              borderColor="gray.200"
+              boxShadow="0 2px 8px rgba(0, 0, 0, 0.06)"
+              overflow="hidden"
+            >
+              <Box bg="purple.50" px={8} py={4}>
+                <HStack justify="space-between" align="center">
+                  <Box>
+                    <Heading size="lg" color="purple.700">Generated Study Material</Heading>
+                    <Text color="purple.600">Ready for your review</Text>
+                  </Box>
+                  <HStack>
+                    <Tooltip label="Copy all" placement="top">
+                      <Button size="sm" variant="outline" onClick={() => {
+                        if (!content) return
+                        navigator.clipboard.writeText(content)
+                          .then(() => toast({ title: 'Copied to clipboard', status: 'success', duration: 2000 }))
+                          .catch(() => toast({ title: 'Copy failed', status: 'error', duration: 2000 }))
+                      }}>Copy</Button>
+                    </Tooltip>
+                    <Tooltip label="Download PDF" placement="top">
+                      <Button size="sm" leftIcon={<Icon as={MdDownload} />} variant="outline" onClick={onDownloadPdf}>PDF</Button>
+                    </Tooltip>
+                    <Tooltip label="Open detailed view" placement="top">
+                      <Button size="sm" colorScheme="purple" variant="solid" onClick={() => navigate(`/content-view?id=${encodeURIComponent(contentId)}`)}>Open</Button>
+                    </Tooltip>
+                  </HStack>
+                </HStack>
+              </Box>
+              
+              <Box p={8} maxW="3xl" mx="auto" lineHeight="tall" ref={contentRef}>
+                <Markdown source={content} />
+              </Box>
 
-            <Divider />
-            
-            <Box p={8} maxW="3xl" mx="auto">
-              <Text fontSize="sm" color="gray.600" mb={4}>
-                What would you like to do next?
-              </Text>
-              <HStack spacing={4}>
-                <Button 
-                  onClick={() => navigate(`/questions?content_id=${contentId}`)} 
-                  bgGradient="linear(to-r, blue.500, teal.500)"
-                  color="white"
-                  borderRadius="10px"
-                  rightIcon={<Icon as={MdArrowForward} />}
-                  _hover={{
-                    bgGradient: "linear(to-r, blue.600, teal.600)",
-                    transform: "translateY(-1px)",
-                  }}
-                >
-                  Create Questions
-                </Button>
-                <Button 
-                  onClick={() => navigate('/dashboard')} 
-                  variant="outline"
-                  borderRadius="10px"
-                  borderColor="gray.300"
-                  _hover={{ bg: 'gray.50' }}
-                >
-                  Back to Dashboard
-                </Button>
-              </HStack>
+              <Divider />
+              
+              <Box p={8} maxW="3xl" mx="auto">
+                <Text fontSize="sm" color="gray.600" mb={4}>
+                  What would you like to do next?
+                </Text>
+                <HStack spacing={4}>
+                  <Button 
+                    onClick={() => navigate(`/questions?content_id=${contentId}`)} 
+                    bgGradient="linear(to-r, blue.500, teal.500)"
+                    color="white"
+                    borderRadius="10px"
+                    rightIcon={<Icon as={MdArrowForward} />}
+                    _hover={{
+                      bgGradient: "linear(to-r, blue.600, teal.600)",
+                      transform: "translateY(-1px)",
+                    }}
+                  >
+                    Create Questions
+                  </Button>
+                  <Button 
+                    onClick={() => navigate('/dashboard')} 
+                    variant="outline"
+                    borderRadius="10px"
+                    borderColor="gray.300"
+                    _hover={{ bg: 'gray.50' }}
+                  >
+                    Back to Dashboard
+                  </Button>
+                </HStack>
+              </Box>
             </Box>
-          </Box>
+            <VStack as="aside" minW={{ base: '0', md: '300px' }} display={{ base: 'none', md: 'flex' }} position="sticky" top="92px" align="stretch">
+              <Box borderWidth="1px" rounded="lg" p={4} bg="white">
+                <Text fontWeight="600" color="gray.700" mb={2}>On this page</Text>
+                <Divider mb={3} />
+                <VStack align="stretch" spacing={2} maxH="70vh" overflowY="auto">
+                  {headings.length === 0 && <Text color="gray.500">No sections</Text>}
+                  {headings.map(h => (
+                    <Button key={h.id} variant="link" justifyContent="flex-start" onClick={() => {
+                      const el = document.getElementById(h.id)
+                      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                    }} pl={Math.min((h.level - 1) * 4, 12)} colorScheme="blackAlpha">
+                      <Text noOfLines={1}>{h.text}</Text>
+                    </Button>
+                  ))}
+                </VStack>
+              </Box>
+            </VStack>
+          </Flex>
         )}
       </Stack>
     </PrivateLayout>

--- a/client/src/pages/ContentView.tsx
+++ b/client/src/pages/ContentView.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Container, Heading, Stack, Text, Flex, VStack, HStack, Divider, Icon, useToast } from '@chakra-ui/react'
+import { Box, Button, Container, Heading, Stack, Text, Flex, VStack, HStack, Divider, Icon, useToast, Tooltip } from '@chakra-ui/react'
 import PrivateLayout from '../components/PrivateLayout'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { getContentById, type ContentOut } from '../api/client'
@@ -78,11 +78,19 @@ export default function ContentViewPage() {
               <HStack justify="space-between" mb={4}>
                 <Heading>{data.topic || 'Study Content'}</Heading>
                 <HStack>
+                  <Tooltip label="Copy all" placement="top">
+                    <Button variant="outline" onClick={() => {
+                      navigator.clipboard.writeText(data.content)
+                        .then(() => toast({ title: 'Copied to clipboard', status: 'success', duration: 2000 }))
+                        .catch(() => toast({ title: 'Copy failed', status: 'error', duration: 2000 }))
+                    }}>Copy</Button>
+                  </Tooltip>
                   <Button leftIcon={<Icon as={MdDownload} />} variant="outline" onClick={onDownloadPdf}>Download PDF</Button>
                   <Button leftIcon={<Icon as={MdOutlineArrowBack} />} onClick={() => navigate('/progress')} variant="ghost">Back</Button>
                 </HStack>
               </HStack>
-              <Box ref={contentRef} borderWidth="1px" rounded="lg" p={6} bg="white">
+              <Box ref={contentRef} borderWidth="1px" rounded="lg" p={6} bg="white" position="relative">
+                <Button size="sm" position="absolute" right="12px" bottom="12px" onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}>Top</Button>
                 <Markdown source={data.content} />
               </Box>
               <Stack direction={{ base: 'column', md: 'row' }} mt={6}>


### PR DESCRIPTION
I enhanced the generated content section in Content.tsx with a right-side table of contents, built from headings in your generated Markdown, so users can jump to sections easily. I added a Download PDF button (and kept Copy and Open actions) on the header of the generated content card. The PDF prints the styled content area. Typography and Markdown rendering were refined earlier for a professional look.